### PR TITLE
security: harden auth, fix SQLite migration ownership, and patch XSS vector

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -22,7 +22,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.24.0'
+          go-version-file: go.mod
 
       - name: Build application
         run: go build ./cmd/vega
@@ -37,7 +37,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.21'
+          go-version-file: go.mod
 
       - name: Check code formatting
         run: |
@@ -60,7 +60,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.21'
+          go-version-file: go.mod
 
       - name: Run tests with coverage
         run: |
@@ -69,10 +69,11 @@ jobs:
           go tool cover -func=coverage.filtered.out
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v5
         with:
-          file: ./coverage.filtered.out
+          files: ./coverage.filtered.out
           flags: unittests
+          token: ${{ secrets.CODECOV_TOKEN }}
 
   summary:
     name: CI Summary

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -30,13 +30,18 @@ jobs:
       
       - name: Set deployment tag
         id: set-tag
+        env:
+          INPUT_SHA: ${{ github.event.inputs.commit_sha }}
         run: |
-          if [ -n "${{ github.event.inputs.commit_sha }}" ]; then
-            echo "tag=${{ github.event.inputs.commit_sha }}" >> $GITHUB_OUTPUT
+          if [ -n "$INPUT_SHA" ]; then
+            if ! echo "$INPUT_SHA" | grep -qE '^[a-f0-9]{7,40}$'; then
+              echo "Error: Invalid commit SHA format"
+              exit 1
+            fi
+            echo "tag=$INPUT_SHA" >> $GITHUB_OUTPUT
           else
             echo "tag=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
           fi
-          echo "Deployment tag: $(cat $GITHUB_OUTPUT)"
       
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v3
@@ -78,16 +83,18 @@ jobs:
     steps:
       - name: Deploy to Hetzner VM
         uses: appleboy/ssh-action@v1.0.0
+        env:
+          DEPLOY_TAG: ${{ needs.build-and-push.outputs.tag }}
         with:
           host: ${{ secrets.HETZNER_HOST }}
           username: ${{ secrets.HETZNER_USERNAME }}
           key: ${{ secrets.HETZNER_SSH_KEY }}
           port: ${{ secrets.HETZNER_SSH_PORT }}
+          envs: DEPLOY_TAG
           script: |
             cd /opt/vega-ai
-            export IMAGE_TAG=cloud-${{ needs.build-and-push.outputs.tag }}
+            export IMAGE_TAG=cloud-${DEPLOY_TAG}
             docker compose pull -q
-            docker compose down --remove-orphans
-            docker compose up -d --quiet-pull
+            docker compose up -d --remove-orphans --quiet-pull
             docker image prune -f
-            echo "✅ Deployment completed"
+            echo "Deployment completed successfully"

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,10 +1,6 @@
 #!/bin/sh
 set -e
 
-generate_token() {
-    head -c 32 /dev/urandom | base64 | tr -d '\n'
-}
-
 # Set COOKIE_SECURE based on mode
 if [ "$CLOUD_MODE" = "true" ]; then
     # Cloud mode MUST use secure cookies for security

--- a/docker/prod/Dockerfile
+++ b/docker/prod/Dockerfile
@@ -22,7 +22,7 @@ FROM alpine:3.22
 
 ARG CLOUD_MODE=false
 
-RUN apk --no-cache add ca-certificates tzdata wget && \
+RUN apk --no-cache add ca-certificates tzdata && \
     addgroup -g 1001 -S appgroup && \
     adduser -u 1001 -S appuser -G appgroup
 

--- a/internal/config/additional_settings_test.go
+++ b/internal/config/additional_settings_test.go
@@ -38,7 +38,7 @@ func TestNewSettings(t *testing.T) {
 				assert.False(t, s.IsCloudMode)
 				assert.Equal(t, 60*time.Minute, s.AccessTokenExpiry)
 				assert.Equal(t, 72*time.Hour, s.RefreshTokenExpiry)
-				assert.Equal(t, 25, s.DBMaxOpenConns)
+				assert.Equal(t, 10, s.DBMaxOpenConns)
 				assert.Equal(t, 256, s.CacheMaxMemoryMB)
 			},
 		},
@@ -115,8 +115,8 @@ func TestNewSettings(t *testing.T) {
 				os.Setenv("CACHE_MAX_MEMORY_MB", "not-a-number")
 			},
 			validate: func(t *testing.T, s Settings) {
-				assert.Equal(t, 60*time.Minute, s.AccessTokenExpiry) // Default
-				assert.Equal(t, 256, s.CacheMaxMemoryMB)             // Default
+				assert.Equal(t, 60*time.Minute, s.AccessTokenExpiry)
+				assert.Equal(t, 256, s.CacheMaxMemoryMB)
 			},
 		},
 		{

--- a/internal/config/settings.go
+++ b/internal/config/settings.go
@@ -10,7 +10,6 @@ import (
 	"time"
 )
 
-// Settings holds the configuration settings for the application.
 type Settings struct {
 	AppName            string
 	ServerPort         string
@@ -67,18 +66,14 @@ type Settings struct {
 	EnableCSRF            bool
 }
 
-// NewSettings initializes and returns a Settings struct with default values
-// populated from environment variables. If an environment variable is
-// not set, a predefined default value is used.
 func NewSettings() Settings {
 	isDevelopment := getEnv("IS_DEVELOPMENT", "false") == "true"
 	isTest := getEnv("GO_ENV", "") == "test"
 	isCloudMode := getEnv("CLOUD_MODE", "false") == "true"
 
-	// Production-optimized defaults
 	accessTokenExpiry := 60 * time.Minute
 	refreshTokenExpiry := 72 * time.Hour
-	dbMaxOpenConns := 25
+	dbMaxOpenConns := 10
 	dbMaxIdleConns := 5
 	dbConnMaxLifetime := 5 * time.Minute
 
@@ -250,7 +245,6 @@ func getEnv(key string, defaultValue string) (value string) {
 	return
 }
 
-// getDefaultLogLevel returns appropriate log level based on environment
 func getDefaultLogLevel(isDevelopment bool) string {
 	if isDevelopment {
 		return "debug"
@@ -258,22 +252,20 @@ func getDefaultLogLevel(isDevelopment bool) string {
 	return "info"
 }
 
-// getCacheMaxMemoryMB returns the max memory for cache in MB
 func getCacheMaxMemoryMB() int {
 	if envVal := getEnv("CACHE_MAX_MEMORY_MB", ""); envVal != "" {
 		if mb, err := strconv.Atoi(envVal); err == nil {
 			return mb
 		}
 	}
-	return 256 // Default 256MB
+	return 256
 }
 
-// getCacheDefaultTTL returns the default TTL for cache entries
 func getCacheDefaultTTL() time.Duration {
 	if envVal := getEnv("CACHE_DEFAULT_TTL", ""); envVal != "" {
 		if duration, err := time.ParseDuration(envVal); err == nil {
 			return duration
 		}
 	}
-	return time.Hour // Default 1 hour
+	return time.Hour
 }

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -21,7 +21,7 @@ type DBConfig struct {
 // DefaultDBConfig returns a DBConfig with recommended default values for SQLite.
 func DefaultDBConfig() DBConfig {
 	return DBConfig{
-		MaxOpenConns:    25,
+		MaxOpenConns:    10,
 		MaxIdleConns:    5,
 		ConnMaxLifetime: 5 * time.Minute,
 		ConnMaxIdleTime: 1 * time.Minute,

--- a/internal/db/migrate.go
+++ b/internal/db/migrate.go
@@ -1,6 +1,7 @@
 package db
 
 import (
+	"database/sql"
 	"errors"
 	"fmt"
 	"path/filepath"
@@ -12,14 +13,19 @@ import (
 )
 
 // MigrateDatabase performs database migrations using the golang-migrate library.
-// It applies all up migrations from the specified migrations directory to the database.
+// It opens a dedicated connection for migrations — golang-migrate owns and closes
+// that connection, so the app's shared pool is unaffected.
 func MigrateDatabase(dbPath, migrationsDir string) error {
 	log.Info().
-		Str("dbPath", dbPath).
 		Str("migrationsDir", migrationsDir).
 		Msg("Starting database migration")
 
-	driver, err := sqlite.WithInstance(SqlDBFromPath(dbPath), &sqlite.Config{})
+	migrationDB, err := sql.Open("sqlite", dbPath+"?_journal_mode=WAL&_busy_timeout=5000")
+	if err != nil {
+		return fmt.Errorf("failed to open migration connection: %w", err)
+	}
+
+	driver, err := sqlite.WithInstance(migrationDB, &sqlite.Config{})
 	if err != nil {
 		return fmt.Errorf("failed to create database driver instance: %w", err)
 	}
@@ -35,12 +41,11 @@ func MigrateDatabase(dbPath, migrationsDir string) error {
 		"sqlite",
 		driver,
 	)
-
 	if err != nil {
 		return fmt.Errorf("failed to create migration instance: %w", err)
 	}
+	defer m.Close()
 
-	log.Info().Msg("Running database migrations...")
 	if err := m.Up(); err != nil {
 		if errors.Is(err, migrate.ErrNoChange) {
 			log.Info().Msg("No migrations to apply, database is up to date")

--- a/internal/db/migrate_test.go
+++ b/internal/db/migrate_test.go
@@ -37,12 +37,12 @@ func TestMigrateDatabase(t *testing.T) {
 	err = MigrateDatabase(dbFile, migrationsDir)
 	require.NoError(t, err)
 
-	db, err := sql.Open("sqlite", dbFile)
+	database, err := sql.Open("sqlite", dbFile)
 	require.NoError(t, err)
-	defer db.Close()
+	defer database.Close()
 
 	var tableName string
-	err = db.QueryRow("SELECT name FROM sqlite_master WHERE type='table' AND name='test_users'").Scan(&tableName)
+	err = database.QueryRow("SELECT name FROM sqlite_master WHERE type='table' AND name='test_users'").Scan(&tableName)
 	require.NoError(t, err)
 	assert.Equal(t, "test_users", tableName)
 

--- a/internal/documents/routes.go
+++ b/internal/documents/routes.go
@@ -4,14 +4,14 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
-func RegisterRoutes(router *gin.RouterGroup, handler *DocumentHandler, authMiddleware gin.HandlerFunc, csrfMiddleware gin.HandlerFunc) {
+func RegisterRoutes(router *gin.RouterGroup, handler *DocumentHandler, authMiddleware gin.HandlerFunc) {
 	documentRoutes := router.Group("/documents")
 	documentRoutes.Use(authMiddleware)
 	{
 		documentRoutes.GET("", handler.GetDocumentsHub)
 		documentRoutes.GET("/partial", handler.GetDocumentPartial)
 		documentRoutes.GET("/:id/export", handler.ExportDocument)
-		documentRoutes.POST("/save", csrfMiddleware, handler.SaveDocument)
-		documentRoutes.DELETE("/:id", csrfMiddleware, handler.DeleteDocument)
+		documentRoutes.POST("/save", handler.SaveDocument)
+		documentRoutes.DELETE("/:id", handler.DeleteDocument)
 	}
 }

--- a/internal/vega/app.go
+++ b/internal/vega/app.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"html/template"
 	"net/http"
+	"net/url"
 	"os"
 	"os/signal"
 	"path/filepath"
@@ -259,6 +260,13 @@ func templateFuncMap() template.FuncMap {
 	return template.FuncMap{
 		"safeHTML": func(s string) template.HTML {
 			return template.HTML(s)
+		},
+		"safeURL": func(s string) template.URL {
+			u, err := url.Parse(s)
+			if err != nil || (u.Scheme != "http" && u.Scheme != "https") {
+				return template.URL("#")
+			}
+			return template.URL(s)
 		},
 		"dict": func(values ...interface{}) (map[string]interface{}, error) {
 			if len(values)%2 != 0 {

--- a/internal/vega/routes.go
+++ b/internal/vega/routes.go
@@ -73,10 +73,12 @@ func SetupRoutes(a *App) {
 
 	authGroup := a.router.Group("/auth")
 
+	// Always initialize rate limiter for auth endpoints (API + page routes)
+	authLimiter := localmiddleware.NewAuthRateLimiter()
+	a.authLimiter = authLimiter
+
 	// Register auth routes
 	if !a.config.IsCloudMode {
-		authLimiter := localmiddleware.NewAuthRateLimiter()
-		a.authLimiter = authLimiter
 		auth.RegisterPublicRoutes(authGroup, authHandler, authLimiter)
 	} else {
 		// In cloud mode, only register the login page route which will redirect to Google OAuth
@@ -96,10 +98,7 @@ func SetupRoutes(a *App) {
 	authGroup.Use(authHandler.AuthMiddleware())
 	auth.RegisterPrivateRoutes(authGroup, authHandler)
 
-	// Homepage route - register different handlers based on mode
 	a.router.GET("/", authHandler.OptionalAuthMiddleware(), homeHandler.GetHomePage)
-
-	// Dashboard route - always shows dashboard
 	a.router.GET("/dashboard", authHandler.OptionalAuthMiddleware(), homeHandler.GetHomePage)
 
 	jobGroup := a.router.Group("/jobs")
@@ -110,11 +109,10 @@ func SetupRoutes(a *App) {
 	settingsGroup.Use(authHandler.AuthMiddleware())
 	settings.RegisterRoutes(settingsGroup, settingsHandler)
 
-	// Register document routes
-	csrfMiddleware := middleware.CSRF(&a.config)
-	documents.RegisterRoutes(&a.router.RouterGroup, documentHandler, authHandler.AuthMiddleware(), csrfMiddleware)
+	documents.RegisterRoutes(&a.router.RouterGroup, documentHandler, authHandler.AuthMiddleware())
 
 	authAPIGroup := a.router.Group("/api/auth")
+	authAPIGroup.Use(a.authLimiter.Middleware())
 	authapi.RegisterRoutes(authAPIGroup, authAPIHandler)
 
 	jobAPIGroup := a.router.Group("/api/jobs")
@@ -132,11 +130,7 @@ func SetupRoutes(a *App) {
 	})
 }
 
-// globalErrorHandler is a Gin middleware that recovers from panics and handles internal server errors
-// by rendering a generic 500 error page.
-//
-// It ensures that any unhandled errors or panics result in a
-// consistent error response to the client.
+// globalErrorHandler recovers from panics and renders a 500 page for unhandled errors.
 func globalErrorHandler(renderer *render.HTMLRenderer) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		defer func() {

--- a/templates/documents/hub.html
+++ b/templates/documents/hub.html
@@ -178,7 +178,7 @@
   };
 </script>
 
-<script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js" integrity="sha384-JcnsjUPPylna1s1fvi1u12X5qjY5OL56iySh75FdtrwhO/SWXgMjoVqcKyIIWOLk" crossorigin="anonymous"></script>
 <script src="/static/js/document-formatter.js"></script>
 <script src="/static/js/pdf-generator.js"></script>
 

--- a/templates/job/details.html
+++ b/templates/job/details.html
@@ -401,7 +401,7 @@
           </a>
 
           {{if .job.SourceURL}}
-          <a href="{{.job.SourceURL}}" target="_blank" class="w-full mb-3 py-3 sm:py-2.5 px-4 bg-slate-600 hover:bg-slate-500 text-white rounded-md text-sm font-medium transition-colors flex items-center justify-center gap-2 min-h-[48px] sm:min-h-0">
+          <a href="{{safeURL .job.SourceURL}}" target="_blank" rel="noopener noreferrer" class="w-full mb-3 py-3 sm:py-2.5 px-4 bg-slate-600 hover:bg-slate-500 text-white rounded-md text-sm font-medium transition-colors flex items-center justify-center gap-2 min-h-[48px] sm:min-h-0">
             <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14" />
             </svg>
@@ -410,7 +410,7 @@
           {{end}}
 
           {{if .job.ApplicationURL}}
-          <a href="{{.job.ApplicationURL}}" target="_blank" class="w-full mb-3 py-3 sm:py-2.5 px-4 bg-primary hover:bg-primary-dark text-white rounded-md text-sm font-medium transition-colors flex items-center justify-center gap-2 min-h-[48px] sm:min-h-0">
+          <a href="{{safeURL .job.ApplicationURL}}" target="_blank" rel="noopener noreferrer" class="w-full mb-3 py-3 sm:py-2.5 px-4 bg-primary hover:bg-primary-dark text-white rounded-md text-sm font-medium transition-colors flex items-center justify-center gap-2 min-h-[48px] sm:min-h-0">
             <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14" />
             </svg>
@@ -449,7 +449,7 @@
 
 <script src="/static/js/ai-operations.js"></script>
 
-<script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js" integrity="sha384-JcnsjUPPylna1s1fvi1u12X5qjY5OL56iySh75FdtrwhO/SWXgMjoVqcKyIIWOLk" crossorigin="anonymous"></script>
 <script src="/static/js/pdf-generator.js"></script>
 
 <script>

--- a/templates/job/new.html
+++ b/templates/job/new.html
@@ -52,27 +52,27 @@
 
             <!-- URL -->
             <div class="col-span-1 md:col-span-3">
-              <label for="url" class="block text-sm font-medium text-gray-300 mb-1">Source URL *</label>
+              <label for="source_url" class="block text-sm font-medium text-gray-300 mb-1">Source URL *</label>
               <div class="relative">
                 <div class="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
                   <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 text-gray-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13.828 10.172a4 4 0 00-5.656 0l-4 4a4 4 0 105.656 5.656l1.102-1.101m-.758-4.899a4 4 0 005.656 0l4-4a4 4 0 00-5.656-5.656l-1.1 1.1" />
                   </svg>
                 </div>
-                <input type="url" id="url" name="source_url"
+                <input type="url" id="source_url" name="source_url"
                        class="w-full pl-10 pr-4 py-3 rounded-md bg-slate-700 bg-opacity-70 border border-slate-600 text-white focus:outline-none focus:ring-2 focus:ring-primary focus:border-primary transition-colors text-base"
                        placeholder="https://example.com/job-posting" required>
               </div>
             </div>
             <div class="col-span-1 md:col-span-3">
-              <label for="url" class="block text-sm font-medium text-gray-300 mb-1">Application URL</label>
+              <label for="application_url" class="block text-sm font-medium text-gray-300 mb-1">Application URL</label>
               <div class="relative">
                 <div class="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
                   <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 text-gray-400" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13.828 10.172a4 4 0 00-5.656 0l-4 4a4 4 0 105.656 5.656l1.102-1.101m-.758-4.899a4 4 0 005.656 0l4-4a4 4 0 00-5.656-5.656l-1.1 1.1" />
                   </svg>
                 </div>
-                <input type="url" id="url" name="application_url"
+                <input type="url" id="application_url" name="application_url"
                        class="w-full pl-10 pr-4 py-3 rounded-md bg-slate-700 bg-opacity-70 border border-slate-600 text-white focus:outline-none focus:ring-2 focus:ring-primary focus:border-primary transition-colors text-base"
                        placeholder="https://example.com/job-application">
               </div>

--- a/templates/layouts/base.html
+++ b/templates/layouts/base.html
@@ -18,9 +18,9 @@
   <link href="/static/css/components.css" rel="stylesheet">
   <link href="/static/css/utilities.css" rel="stylesheet">
   <link href="/static/css/print.css" rel="stylesheet" media="print">
-  <script src="https://unpkg.com/htmx.org@1.9.4"></script>
-  <script src="https://unpkg.com/htmx.org@1.9.4/dist/ext/response-targets.js"></script>
-  <script src="https://unpkg.com/hyperscript.org@0.9.12"></script>
+  <script src="https://unpkg.com/htmx.org@1.9.4" integrity="sha384-zUfuhFKKZCbHTY6aRR46gxiqszMk5tcHjsVFxnUo8VMus4kHGVdIYVbOYYNlKmHV" crossorigin="anonymous"></script>
+  <script src="https://unpkg.com/htmx.org@1.9.4/dist/ext/response-targets.js" integrity="sha384-Y1ICOa9aa1Ms7kkIJauP2Qeqw8JF0ygqHQPZ1xJgNra7uS5rAC4ywTk3voPppm+W" crossorigin="anonymous"></script>
+  <script src="https://unpkg.com/hyperscript.org@0.9.12" integrity="sha384-+Uth1QzYJsTjnS5SXVN3fFO4I32Y571xIuv53WJ2SA7y5/36tKU1VCutONAmg5eH" crossorigin="anonymous"></script>
   <script>
     document.addEventListener('DOMContentLoaded', function() {
       htmx.config.responseTargetUnsetsError = true;
@@ -354,16 +354,22 @@
           } else if (event.detail.xhr.status >= 500) {
             event.detail.shouldSwap = false;
             if (event.detail.target) {
-              event.detail.target.innerHTML = `
-                <div class="bg-red-900 bg-opacity-50 border border-red-700 text-red-200 p-3 rounded-md mb-3 text-sm" _="on load wait 5s then transition opacity to 0 over 0.5s then remove me">
-                  <div class="flex items-center">
-                    <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4 mr-2 text-red-400 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
-                    </svg>
-                    <span>Something went wrong. Please try again later.</span>
-                  </div>
+              const errDiv = document.createElement('div');
+              errDiv.className = 'bg-red-900 bg-opacity-50 border border-red-700 text-red-200 p-3 rounded-md mb-3 text-sm';
+              errDiv.innerHTML = `
+                <div class="flex items-center">
+                  <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4 mr-2 text-red-400 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+                  </svg>
+                  <span>Something went wrong. Please try again later.</span>
                 </div>
               `;
+              event.detail.target.prepend(errDiv);
+              setTimeout(() => {
+                errDiv.style.transition = 'opacity 0.5s';
+                errDiv.style.opacity = '0';
+                setTimeout(() => errDiv.remove(), 500);
+              }, 5000);
             }
           }
         });

--- a/templates/settings/settings_profile.html
+++ b/templates/settings/settings_profile.html
@@ -371,7 +371,7 @@
                   {{end}}
                   {{if .CredentialURL}}
                     <p class="text-gray-300">
-                      <a href="{{.CredentialURL}}" target="_blank" class="text-primary hover:text-primary-light">View Credential</a>
+                      <a href="{{safeURL .CredentialURL}}" target="_blank" rel="noopener noreferrer" class="text-primary hover:text-primary-light">View Credential</a>
                     </p>
                   {{end}}
                 </div>


### PR DESCRIPTION
## What's this about?

This PR adds security and reliability hardening pass across the stack:  CI/CD pipeline, Docker, Go backend, and templates. 

**CI/CD**
- Go version sourced from `go.mod` (`go-version-file`) across all CI jobs
- Codecov upgraded v3 → v5 with explicit token (v3 had a supply chain incident)
- Deploy workflow: `commit_sha` input is now passed via `env:` and validated against `^[a-f0-9]{7,40}$` before use, eliminating script injection via `${{ github.event.inputs.* }}` direct interpolation
- `docker compose down + up` replaced with `docker compose up --remove-orphans`

**Docker**
- `wget` removed from Alpine image
- Dead `generate_token()` shell function removed from `entrypoint.sh` (was defined but never called since a prior refactor)

**Backend**
- `DBMaxOpenConns` reduced 25 → 10 (appropriate for SQLite's single-writer model)
- Auth rate limiter always initialised and applied to `/api/auth` group (was previously skipped in cloud mode)
- CSRF middleware de-duplicated: removed per-route application in `documents/routes.go` since the global router middleware already covers all routes
- `safeURL` template function added. It enforces `http`/`https` scheme at render time, falling back to `#`, providing a second defence layer independent of input validation

**Templates**
- SRI hashes added to all CDN-loaded scripts (htmx, hyperscript, jspdf) 
- `rel="noopener noreferrer"` added to all `target="_blank"` links 
- `javascript:` URIs now blocked at render time via `safeURL` on all user-supplied URL fields (`SourceURL`, `ApplicationURL`, `CredentialURL`)
- HTMX 500 error banner replaced `innerHTML` + Hyperscript `_=` attribute (which Hyperscript never processes post-injection) with `createElement` + `setTimeout` 
- HTML `<label for="">` attributes corrected to match `source_url` and `application_url` input IDs

## Why this matters

- The deploy script was vulnerable to shell injection via a user-controlled GitHub Actions input interpolated directly into a `run:` block
- `javascript:` URIs stored in the DB before input validation existed (or via a non-validated path) would have been rendered as live XSS vectors
- The HTMX 500 error banner was permanently stuck because the auto-dismiss Hyperscript was silently ignored on `innerHTML`-injected elements

## How was this tested?

- [x] Tested locally
- [x] All tests pass
- [x] Manually verified the change works as expected
