### PR TITLE
chore: upgrade docker/build-push-action from v5 to v6

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -63,7 +63,7 @@ jobs:
         uses: docker/setup-buildx-action@v3
       
       - name: Build and push Docker image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
         with:
           context: .
           file: ./docker/prod/Dockerfile

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -76,7 +76,7 @@ jobs:
         fi
 
     - name: Build and push Docker image
-      uses: docker/build-push-action@v5
+      uses: docker/build-push-action@v6
       with:
         context: .
         file: ./docker/prod/Dockerfile


### PR DESCRIPTION
## What's this about?

This PR upgrades the `docker/build-push-action` GitHub Action from `v5` to `v6` in both CI workflows (`deploy.yml` and `docker-build.yml`).

## Why this matters

`docker/build-push-action@v6` includes upstream improvements and bug fixes from the Docker team. Keeping Actions pinned to outdated major versions accumulates technical debt and may miss security patches or compatibility fixes for newer Docker/BuildKit features. This is a routine maintenance bump to stay current.

## How was this tested?

- [x] Tested locally
- [x] All tests pass
